### PR TITLE
Add install field in opam file

### DIFF
--- a/opam
+++ b/opam
@@ -9,8 +9,8 @@ license: "GPLv2"
 build: [
   [ "oasis" "setup" ]
   [ make ]
-  [ make "install" ]
 ]
+install: [ make "install" ]
 remove: [ "ocamlfind" "remove" "perf" ]
 depends: ["ocamlfind" {build} "oasis" "ocplib-endian" "sexplib" "oclock"]
 dev-repo: "git://github.com/OCamlPro/ocaml-perf"


### PR DESCRIPTION
Installation of perf fails under opam.2.0.0 due to sandboxed builds. opam 2.0 requires an explicit install field for moving targets to the final location. This PR moves `make install` to a separate field. 